### PR TITLE
Remove event_focus condition

### DIFF
--- a/dist/yearpicker.js
+++ b/dist/yearpicker.js
@@ -315,9 +315,7 @@ const Yearpicker = (function () {
       if ($.isFunction(options.click)) {
         $element.on(event_click, options.click);
       }
-      if ($this.isInput) {
-        $element.on(event_focus, $.proxy($this.showView, $this));
-      } else {
+     else {
         $element.on(event_click, $.proxy($this.showView, $this));
       }
     },


### PR DESCRIPTION
I'm not sure if this is specific only to my input text in chrome, but you can double-check and let me know
```
                    <input type="text" id="year" placeholder="{% trans %}Enter an year YYYY{% endtrans %}"
                           title="{% trans %}Access starting from this year{% endtrans %}" size="5">
```